### PR TITLE
Guide formatting problems fixed

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -9,7 +9,6 @@ permalink: /guides/use-appsody-cli/
 :page-description: Learn about the common Appsody CLI commands that you'll use to develop applications
 :page-tags: ['Appsody', 'CLI']
 :page-guide-category: basic
-
 = Developing with the Appsody CLI
 
 //	Copyright 2019 IBM Corporation and others.


### PR DESCRIPTION
Guide looks fine in GitHub, but when built in to the website
the title is missing. Removed a blank line below the front matter.

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>