### PR TITLE
Updates flowing from Appsody changes

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -9,7 +9,7 @@ permalink: /guides/use-appsody-cli/
 :page-description: Learn about the common Appsody CLI commands that you'll use to develop applications
 :page-tags: ['Appsody', 'CLI']
 :page-guide-category: basic
-= Developing with the Appsody CLI
+= Developing microservice applcations with the Appsody CLI
 
 //	Copyright 2019 IBM Corporation and others.
 //
@@ -77,7 +77,7 @@ output indicates the default repository.
 [source,bash]
 ----
 NAME            URL
-*appsodyhub     https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml
+*incubator      https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml
 experimental    https://github.com/appsody/stacks/releases/latest/download/experimental-index.yaml
 ----
 
@@ -110,7 +110,7 @@ again. The output should be similar to the following example:
 [source,bash]
 ----
 NAME          URL
-*appsodyhub   https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml
+*incubator    https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml
 experimental  https://github.com/appsody/stacks/releases/latest/download/experimental-index.yaml
 kabanero      https://github.com/kabanero-io/collections/releases/latest/download/kabanero-index.yaml
 ----
@@ -131,7 +131,7 @@ Run `appsody repo list` again to check that `kabanero` is now the default reposi
 ----
 NAME            URL
 *kabanero       https://github.com/kabanero-io/collections/releases/latest/download/kabanero-index.yaml
-appsodyhub      https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml
+incubator       https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml
 experimental    https://github.com/appsody/stacks/releases/latest/download/experimental-index.yaml
 ----
 


### PR DESCRIPTION
Repository lists now show incubator instead of appsodyhub.

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>